### PR TITLE
fix: make models pickleable

### DIFF
--- a/river_torch/anomaly/ae.py
+++ b/river_torch/anomaly/ae.py
@@ -11,6 +11,19 @@ from river_torch.utils import dict2tensor
 from river_torch.utils.tensor_conversion import df2tensor
 
 
+class _TestAutoencoder(torch.nn.Module):
+            def __init__(self, n_features, latent_dim=3):
+                super(_TestAutoencoder, self).__init__()
+                self.linear1 = nn.Linear(n_features, latent_dim)
+                self.nonlin = torch.nn.LeakyReLU()
+                self.linear2 = nn.Linear(latent_dim, n_features)
+
+            def forward(self, X, **kwargs):
+                X = self.linear1(X)
+                X = self.nonlin(X)
+                X = self.linear2(X)
+                return nn.functional.sigmoid(X)
+
 class Autoencoder(DeepEstimator, AnomalyDetector):
     """
     Wrapper for PyTorch autoencoder models that uses the networks reconstruction error for scoring the anomalousness of a given example.
@@ -103,21 +116,10 @@ class Autoencoder(DeepEstimator, AnomalyDetector):
             Dictionary of parameters to be used for unit testing the respective class.
         """
 
-        class MyAutoEncoder(torch.nn.Module):
-            def __init__(self, n_features, latent_dim=3):
-                super(MyAutoEncoder, self).__init__()
-                self.linear1 = nn.Linear(n_features, latent_dim)
-                self.nonlin = torch.nn.LeakyReLU()
-                self.linear2 = nn.Linear(latent_dim, n_features)
-
-            def forward(self, X, **kwargs):
-                X = self.linear1(X)
-                X = self.nonlin(X)
-                X = self.linear2(X)
-                return nn.functional.sigmoid(X)
+        
 
         yield {
-            "module": MyAutoEncoder,
+            "module": _TestAutoencoder,
             "loss_fn": "mse",
             "optimizer_fn": "sgd",
         }
@@ -135,7 +137,6 @@ class Autoencoder(DeepEstimator, AnomalyDetector):
             Set of checks to skip during unit testing.
         """
         return {
-            "check_pickling",
             "check_shuffle_features_no_impact",
             "check_emerging_features",
             "check_disappearing_features",

--- a/river_torch/anomaly/scaler.py
+++ b/river_torch/anomaly/scaler.py
@@ -4,8 +4,7 @@ import numpy as np
 from river import base
 from river.anomaly import HalfSpaceTrees
 from river.anomaly.base import AnomalyDetector
-from river.stats import (EWMean, Max, Mean, Min, RollingMax, RollingMean,
-                         RollingMin)
+from river.stats import EWMean, Max, Mean, Min, RollingMax, RollingMean, RollingMin
 
 METRICS = {
     "mean": {"incremental": Mean, "rolling": RollingMean, "adaptive": EWMean},
@@ -87,7 +86,6 @@ class AnomalyScaler(base.Wrapper, AnomalyDetector):
             Set of checks to skip during unit testing.
         """
         return {
-            "check_pickling",
             "check_shuffle_features_no_impact",
             "check_emerging_features",
             "check_disappearing_features",

--- a/river_torch/classification/classifier.py
+++ b/river_torch/classification/classifier.py
@@ -7,8 +7,27 @@ from river.base.typing import ClfTarget
 from torch import nn
 
 from river_torch.base import DeepEstimator
-from river_torch.utils.tensor_conversion import (df2tensor, dict2tensor,
-                                                 labels2onehot, output2proba)
+from river_torch.utils.tensor_conversion import (
+    df2tensor,
+    dict2tensor,
+    labels2onehot,
+    output2proba,
+)
+
+
+class _TestModule(torch.nn.Module):
+    def __init__(self, n_features):
+        super(_TestModule, self).__init__()
+        self.dense0 = torch.nn.Linear(n_features, 5)
+        self.nonlin = torch.nn.ReLU()
+        self.dense1 = torch.nn.Linear(5, 2)
+        self.softmax = torch.nn.Softmax(dim=-1)
+
+    def forward(self, X, **kwargs):
+        X = self.nonlin(self.dense0(X))
+        X = self.nonlin(self.dense1(X))
+        X = self.softmax(X)
+        return X
 
 
 class Classifier(DeepEstimator, base.Classifier):
@@ -106,22 +125,8 @@ class Classifier(DeepEstimator, base.Classifier):
             Dictionary of parameters to be used for unit testing the respective class.
         """
 
-        class MyModule(torch.nn.Module):
-            def __init__(self, n_features):
-                super(MyModule, self).__init__()
-                self.dense0 = torch.nn.Linear(n_features, 5)
-                self.nonlin = torch.nn.ReLU()
-                self.dense1 = torch.nn.Linear(5, 2)
-                self.softmax = torch.nn.Softmax(dim=-1)
-
-            def forward(self, X, **kwargs):
-                X = self.nonlin(self.dense0(X))
-                X = self.nonlin(self.dense1(X))
-                X = self.softmax(X)
-                return X
-
         yield {
-            "module": MyModule,
+            "module": _TestModule,
             "loss_fn": "l1",
             "optimizer_fn": "sgd",
         }
@@ -138,7 +143,6 @@ class Classifier(DeepEstimator, base.Classifier):
             Set of checks to skip during unit testing.
         """
         return {
-            "check_pickling",
             "check_shuffle_features_no_impact",
             "check_emerging_features",
             "check_disappearing_features",
@@ -266,7 +270,6 @@ class Classifier(DeepEstimator, base.Classifier):
         self.module.eval()
         y_preds = self.module(X)
         return output2proba(y_preds, self.observed_classes)
-
 
     def find_output_layer(self) -> nn.Linear:
         """Return the output layer of a network.


### PR DESCRIPTION
Moved PyTorch modules for unit testing to the top level of their respective module to allow pickling. 